### PR TITLE
override mysql container memory settings to reduce required memory footprint

### DIFF
--- a/db/Dockerfile
+++ b/db/Dockerfile
@@ -1,0 +1,14 @@
+
+# db/Dockerfile:
+#
+# customization of mysql.cnf of the datajoint/mysql container
+# to lower memory requirements.
+#
+# built as separate container since config needs to be read-only
+# and making read only as a volume mount of the configuration can
+# be tricky/less user friendly in some cases.
+
+FROM datajoint/mysql:5.7
+
+COPY mysql.cnf /etc/mysql/mysql.cnf
+

--- a/db/mysql.cnf
+++ b/db/mysql.cnf
@@ -1,0 +1,115 @@
+
+# mysql.cnf
+#
+# extracted from datajoint/mysql container /etc/mysql/mysql.cnf via:
+#   docker cp <ctid>:/etc/mysql/mysql.cnf .
+#
+# changes to stock:
+#
+#   - innodb_buffer_pool_size adjusted to 1G
+
+# Copyright (c) 2014, 2015, Oracle and/or its affiliates. All rights reserved.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301 USA
+
+#
+# The MySQL Community Server configuration file.
+#
+# For explanations see
+# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+
+[client]
+port		= 3306
+socket		= /var/run/mysqld/mysqld.sock
+
+# Certificates to enforce strict encryption in MySQL CLI client.
+# i.e. only allow a specific target server
+#ssl-cert=/mysql_keys/client-cert.pem
+#ssl-key=/mysql_keys/client-key.pem
+
+[mysqld_safe]
+pid-file	= /var/run/mysqld/mysqld.pid
+socket		= /var/run/mysqld/mysqld.sock
+nice		= 0
+
+[mysqld]
+skip-host-cache
+skip-name-resolve
+user		= mysql
+pid-file	= /var/run/mysqld/mysqld.pid
+socket		= /var/run/mysqld/mysqld.sock
+port		= 3306
+basedir		= /usr
+datadir		= /var/lib/mysql
+tmpdir		= /tmp
+lc-messages-dir	= /usr/share/mysql
+explicit_defaults_for_timestamp
+
+# configure mode for MySQL appropriate for use with DataJoint
+sql-mode="STRICT_ALL_TABLES,NO_ENGINE_SUBSTITUTION,ONLY_FULL_GROUP_BY"
+
+# Accommodate large data packets
+max_allowed_packet=512M
+innodb_log_file_size=2G
+innodb_buffer_pool_size=1G
+innodb_log_buffer_size=8M
+innodb_file_per_table=1
+innodb_stats_on_metadata=0
+
+# Longer timeouts for datajoint populate jobs, workgroup lan interactivity, rollback on timeout
+wait_timeout=86400		# leave open over weekend
+interactive_timeout=86400	# leave open over weekend
+net_read_timeout=3600		# long make() calls (1H/rec)
+net_write_timeout=3600		# long make() calls (1H/rec)
+lock_wait_timeout=600		# longer timeout for make() contention
+innodb_lock_wait_timeout=600	# longer timeout for make() contention
+innodb_rollback_on_timeout = ON  # ensures entire transactions are rolled back if they timeout
+
+# Initiate Recovery (WARNING: potential data loss if uncommented!)
+#innodb_force_recovery=1
+
+# Instead of skip-networking the default is now to listen only on
+# localhost which is more compatible and is not less secure. Turn 
+# ON to enable MySQL to ONLY allow SSL connections.
+#bind-address = 0.0.0.0
+
+# Turn ON to enable MySQL to ONLY allow SSL connections.
+#require_secure_transport = ON
+
+# Disable SSL
+#ssl = 0
+
+# Enable SSL
+ssl = 1
+ssl-cipher=DHE-RSA-AES256-SHA
+ssl-ca=/mysql_keys/ca.pem
+ssl-cert=/mysql_keys/server-cert.pem
+ssl-key=/mysql_keys/server-key.pem
+
+# Set default auth plugin
+default_authentication_plugin=mysql_native_password
+
+#log-error	= /var/log/mysql/error.log
+
+# Disabling symbolic-links is recommended to prevent assorted security risks
+symbolic-links=0
+
+# Limits directories from which MySQL can load data from. Definition 
+# required for MySQL8.
+secure_file_priv=NULL
+
+# * IMPORTANT: Additional settings that can override those from this file!
+#   The files must end with '.cnf', otherwise they'll be ignored.
+#
+!includedir /etc/mysql/conf.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,10 @@
 version: "2.4"
 services:
+
   db:
-    image: datajoint/mysql:5.7
+    build:
+      context: db
+    image: s1alm-db:v0.0.0
     environment:
       - MYSQL_ROOT_PASSWORD=simple
     ports:
@@ -15,6 +18,7 @@ services:
       interval: 10s
     networks:
       - main
+
   pipeline:
     build:
       context: .
@@ -33,7 +37,7 @@ services:
       - -c
       - |
         s1alm_ingest &
-        jupyter lab
+        jupyter lab --no-browser
     volumes:
       - ./nwb_data:/main/nwb_data
     networks:
@@ -41,5 +45,6 @@ services:
     depends_on:
       db:
         condition: service_healthy
+
 networks:
   main:


### PR DESCRIPTION
the stock 4G innodb_buffer_pool_size can result in overprovisioned memory
allocations in smaller systems (e.g. docker for windows VM, etc).

this change overrides the mysql.cnf from the datajoint/mysql container to
set innodb_buffer_pool_size to 1GB, lowering the base requirement and
reducing the likelihood of memory overprovisioning.

based on current tests, the docker system should have ~2GB free to run the
system (1.5 for the db container, and another ~256-512 for
the pipeline container) vs ~4-5GB previously required.