### PR TITLE
bugfix in missing `training_type`

### DIFF
--- a/pipeline_py/__init__.py
+++ b/pipeline_py/__init__.py
@@ -13,6 +13,7 @@ while not is_initialized:
         experiment = dj.create_virtual_module('experiment', db_prefix + 'experiment')
         ephys = dj.create_virtual_module('ephys', db_prefix + 'ephys')
         misc = dj.create_virtual_module('misc', db_prefix + 'misc')
+        analysis = dj.create_virtual_module('analysis', db_prefix + 'analysis')
 
         len(experiment.BehaviorTrial.Event())
         len(ephys.Unit())

--- a/pipeline_py/nwb_to_datajoint.py
+++ b/pipeline_py/nwb_to_datajoint.py
@@ -88,6 +88,8 @@ def ingest_to_pipeline(nwb_filepath):
                                     'username': nwbfile.experimenter[0], 'rig': 'ephys'})
         experiment.SessionComment.insert1({**session_key, 'session_comment': nwbfile.data_collection})
         experiment.SessionTask.insert1(session_details, ignore_extra_fields=True)
+        if "training_type" not in session_details:
+            session_details["training_type"] = "regular"
         experiment.SessionTraining.insert1(session_details, ignore_extra_fields=True)
 
     units_df = nwbfile.units.to_dataframe()


### PR DESCRIPTION
This pull request introduces a new virtual module and improves the robustness of session data ingestion. The main changes are the addition of the `analysis` module and a safeguard for the `training_type` field in session details.

**Module additions:**
* Added creation of the `analysis` virtual module in `pipeline_py/__init__.py`, allowing for future analysis-related functionality to be accessed through DataJoint.

**Data ingestion improvements:**
* Ensured that the `training_type` field is present in `session_details` during NWB file ingestion, defaulting to `"regular"` if missing, to prevent errors during database insertion.